### PR TITLE
Metainfo update

### DIFF
--- a/client/src/models/metaInfo/metaInfo.ts
+++ b/client/src/models/metaInfo/metaInfo.ts
@@ -7,7 +7,7 @@ import { DateHelper } from '../../helpers/dateHelper';
 import { DataSource } from './dataSource';
 import { FileSystemHelper } from '../../helpers/fileSystemHelper';
 import { JsHelper } from '../../helpers/jsHelper';
-import { ParseException } from '../ParseException';
+import { ParseException } from '../parseException';
 import { YamlHelper } from '../../helpers/yamlHelper';
 
 export class MetaInfo {
@@ -80,7 +80,6 @@ export class MetaInfo {
 			metaInfo.addEventDescriptions(eventDescriptions);
 		}
 
-		metaInfo.setOrigin(metaDict.Origin);
 		metaInfo.setObjectId(metaInfoAsInFile.ObjectId);
 
 		if (metaDict.KnowledgeHolders) {
@@ -148,6 +147,7 @@ export class MetaInfo {
 
 	public setCreatedDate(date: Date): void {
 		this.Created = date;
+		this.FormattedCreated = DateHelper.dateToString(date);
 	}
 
 	public getCreatedDate(): Date {
@@ -156,6 +156,7 @@ export class MetaInfo {
 
 	public setUpdatedDate(date: Date) {
 		this.Updated = date;
+		this.FormattedUpdated = DateHelper.dateToString(date);
 	}
 
 	public setName(name: string) {
@@ -172,14 +173,6 @@ export class MetaInfo {
 
 	public getObjectId(): string | undefined {
 		return this.ObjectId;
-	}
-
-	public setOrigin(origin: string) {
-		this.Origin = origin;
-	}
-
-	public getOrigin(): string | undefined {
-		return this.Origin;
 	}
 
 	public setUseCases(usecase: string[]) {
@@ -285,24 +278,6 @@ export class MetaInfo {
 		return this.References;
 	}
 
-	public setTags(tags: string[]) {
-		if (!tags) {
-			this.Tags = [];
-			return;
-		}
-
-		if (tags.length == 1 && tags[0] == "") {
-			this.Tags = [];
-			return;
-		}
-
-		this.Tags = tags;
-	}
-
-	public getTags(): string[] {
-		return this.Tags;
-	}
-
 	public getAttacks(): Attack[] {
 		return this.ATTACK;
 	}
@@ -332,18 +307,18 @@ export class MetaInfo {
 			metaInfoFullPath = path.join(this.getDirectoryPath(), MetaInfo.METAINFO_FILENAME);
 		}
 
+		this.setUpdatedDate(new Date());
 
 		// Если дата создания не задана, то будет текущая.
-		const updatedDate = new Date();
 		if (!this.Created) {
-			this.Created = updatedDate;
+			this.setCreatedDate(this.Updated);
 		}
 
 		// Обновляем метаданные на диске известными нам полями, оставляя другие неизменными
 		const metaInfoObject = this._asInFile;
 
 		metaInfoObject.ExpertContext.Created = DateHelper.dateToString(this.Created);
-		metaInfoObject.ExpertContext.Updated = DateHelper.dateToString(updatedDate);
+		metaInfoObject.ExpertContext.Updated = DateHelper.dateToString(this.Updated);
 
 		if (this.Name) {
 			metaInfoObject.ContentAutoName = this.Name;
@@ -354,10 +329,6 @@ export class MetaInfo {
 				this.EventDescriptions.map(function (ed, index) {
 					return { "Criteria": ed.getCriteria(), "LocalizationId": ed.getLocalizationId() };
 				});
-		}
-
-		if (this.Origin) {
-			metaInfoObject.ExpertContext.Origin = this.Origin;
 		}
 
 		if (this.ObjectId) {
@@ -374,10 +345,6 @@ export class MetaInfo {
 
 		if (this.Falsepositives.length != 0) {
 			metaInfoObject.ExpertContext.Falsepositives = this.Falsepositives;
-		}
-
-		if (this.Tags.length != 0) {
-			metaInfoObject.ExpertContext.Tags = this.Tags;
 		}
 
 		if (this.References.length != 0) {
@@ -433,16 +400,16 @@ export class MetaInfo {
 
 	private Created: Date;
 	private Updated: Date;
+	private FormattedCreated: string;
+	private FormattedUpdated: string;
 	private Name: string | undefined = undefined;
 	private ObjectId: string | undefined = undefined;
-	private Origin: string | undefined = undefined;
 
 	private KnowledgeHolders: string[] = [];
 	private Usecases: string[] = [];
 	private References: string[] = [];
 	private Falsepositives: string[] = [];
 	private Improvements: string[] = [];
-	private Tags: string[] = [];
 
 	private DataSources: DataSource[] = [];
 	private ATTACK: Attack[] = [];

--- a/client/src/test/rules/correlations/correlations.parseFromDirectory.test.ts
+++ b/client/src/test/rules/correlations/correlations.parseFromDirectory.test.ts
@@ -6,7 +6,7 @@ import { TestFixture } from '../../helper';
 
 suite('Correlations.parseFromDirectory', () => {
 
-	test('Попытка парсинга несуществующей корреляции', async() => {
+	test('Попытка парсинга несуществующей корреляции', async () => {
 		const rulePath = TestFixture.getCorrelationPath("qwertyuiopasdfghjk");
 		assert.rejects(Correlation.parseFromDirectory(rulePath));
 	});
@@ -49,14 +49,12 @@ suite('Correlations.parseFromDirectory', () => {
 
 		const metaInfo = correlation.getMetaInfo();
 		assert.strictEqual(metaInfo.getName(), 'Active_Directory_Snapshot');
-		assert.strictEqual(metaInfo.getOrigin(), 'Local');
 		assert.strictEqual(metaInfo.getObjectId(), 'LOC-CR-2539352345');
 		assert.deepStrictEqual(metaInfo.getKnowledgeHolders(), ['Ivan Ivanov']);
 		assert.deepStrictEqual(metaInfo.getUseCases(), ['LDAP-запросы для выгрузки полной структуры AD генерируемый инструментом AdExplorer при создании снепшота']);
 		assert.deepStrictEqual(metaInfo.getFalsePositives(), []);
-		assert.deepStrictEqual(metaInfo.getTags(), []);
 		assert.deepStrictEqual(metaInfo.getReferences(), ['https://techcommunity.microsoft.com/t5/sysinternals/create-snapshots-with-active-directory-explorer-ad-explorer-from/m-p/2232412']);
-		assert.deepStrictEqual(metaInfo.getImprovements(), ['Добавить adexplorer с ключом -snapshot в подозрительные команды'], );
+		assert.deepStrictEqual(metaInfo.getImprovements(), ['Добавить adexplorer с ключом -snapshot в подозрительные команды'],);
 
 		// Атаки по MITRE.
 		const attacks = metaInfo.getAttacks();
@@ -86,15 +84,15 @@ suite('Correlations.parseFromDirectory', () => {
 		const integrationsTest1 = integrationTests[0];
 		assert.strictEqual(integrationsTest1.getNumber(), 1);
 		const testCode1 = integrationsTest1.getTestCode();
-		assert.strictEqual(testCode1, 
-`expect 1 {"subject.account.name": "pushkin", "src.port": 63691,  "origin_app_id": "00000000-0000-0000-0000-000000000005", "labels": "whitelisted", "subject": "account", "_rule": "Active_Directory_Snapshot", "subject.account.domain": "testlab", "object": "resource", "primary_siem_app_id": "00000000-0000-0000-0000-000000000005", "src.ip": "172.16.222.132", "subject.account.id": "S-1-5-21-1129291328-2819992169-918366777-1118",  "src.host": "172.16.222.132", "incident.category": "Undefined", "correlation_name": "Active_Directory_Snapshot", "action": "access",  "time": "2022-03-28T14:47:27Z", "correlation_type": "event", "incident.aggregation.timeout": 7200,  "alert.context": "|(objectClass=attributeSchema)|(objectClass=classSchema)|(objectClass=displaySpecifier)|(objectClass=controlAccessRight)", "importance": "medium", "count": 1,  "incident.aggregation.key": "Active_Directory_Snapshot|S-1-5-21-1129291328-2819992169-918366777-1118|172.16.222.132", "incident.severity": "medium", "generator.type": "correlationengine", "status": "success", "alert.key": "pushkin|172.16.222.132", "normalized": true, "category.generic": "Attack"}`);
+		assert.strictEqual(testCode1,
+			`expect 1 {"subject.account.name": "pushkin", "src.port": 63691,  "origin_app_id": "00000000-0000-0000-0000-000000000005", "labels": "whitelisted", "subject": "account", "_rule": "Active_Directory_Snapshot", "subject.account.domain": "testlab", "object": "resource", "primary_siem_app_id": "00000000-0000-0000-0000-000000000005", "src.ip": "172.16.222.132", "subject.account.id": "S-1-5-21-1129291328-2819992169-918366777-1118",  "src.host": "172.16.222.132", "incident.category": "Undefined", "correlation_name": "Active_Directory_Snapshot", "action": "access",  "time": "2022-03-28T14:47:27Z", "correlation_type": "event", "incident.aggregation.timeout": 7200,  "alert.context": "|(objectClass=attributeSchema)|(objectClass=classSchema)|(objectClass=displaySpecifier)|(objectClass=controlAccessRight)", "importance": "medium", "count": 1,  "incident.aggregation.key": "Active_Directory_Snapshot|S-1-5-21-1129291328-2819992169-918366777-1118|172.16.222.132", "incident.severity": "medium", "generator.type": "correlationengine", "status": "success", "alert.key": "pushkin|172.16.222.132", "normalized": true, "category.generic": "Attack"}`);
 
 		const integrationsTest2 = integrationTests[1];
 		assert.strictEqual(integrationsTest2.getNumber(), 2);
 		const testCode2 = integrationsTest2.getTestCode();
 
 		const expectedTestCode2 =
-`# Вайтлист
+			`# Вайтлист
 table_list default
 table_list {\"Common_whitelist_auto\":[{\"rule\":\"Active_Directory_Snapshot\",\"specific_value\": \"pushkin|172.16.222.132\"}]}
 expect not {\"correlation_name\": \"Active_Directory_Snapshot\"}`;

--- a/client/src/views/metaInfo/metaInfoUpdater.ts
+++ b/client/src/views/metaInfo/metaInfoUpdater.ts
@@ -9,10 +9,9 @@ import { IncorrectFieldFillingException } from '../incorrectFieldFillingExceptio
 
 
 export class MetaInfoUpdater {
-	public update(metaInfo : MetaInfo, fields : any) : MetaInfo {
+	public update(metaInfo: MetaInfo, fields: any): MetaInfo {
 
 		metaInfo.setName(fields.Name);
-		metaInfo.setOrigin(fields.Origin);
 
 		const useCases = this.filterAndTrimArray(fields.Usecases);
 		metaInfo.setUseCases(useCases);
@@ -30,46 +29,45 @@ export class MetaInfoUpdater {
 		metaInfo.setReferences(references);
 
 		const tags = this.filterAndTrimArray(fields.Tags);
-		metaInfo.setTags(tags);
 
-		if(fields.DataSources) {
+		if (fields.DataSources) {
 			const dataSources = Array.from(fields.DataSources)
-				.map(dt => classTransformer.plainToInstance(DataSource, dt) );
+				.map(dt => classTransformer.plainToInstance(DataSource, dt));
 
 			// Встречаются null в случае несоответствия типа элемента списка с number.
 			const errorDs = dataSources.find(ds => ds.EventID.some(ei => !ei));
-			if(errorDs) {
+			if (errorDs) {
 				throw new IncorrectFieldFillingException(`Некорректное заполнение списка событий провайдера '${errorDs.Provider}', который должен быть указаны в виде списка идентификаторов через запятую.`);
 			}
 
 			metaInfo.setDataSources(dataSources);
 		}
 
-		if(fields.ATTACK) {
+		if (fields.ATTACK) {
 			const attacks = Array.from(fields.ATTACK)
 				.map(dt => classTransformer.plainToInstance(Attack, dt));
 
-			for(const attack of attacks) {
-				const validationResult = attack.Techniques.every( t => {
+			for (const attack of attacks) {
+				const validationResult = attack.Techniques.every(t => {
 					const result = /T(\d+\.\d+|\d+)/g.test(t);
 					return result;
 				});
 
-				if(!validationResult) {
-					throw new IncorrectFieldFillingException(`Некорректное заполнение тактики '${attack.Tactic}'. Техники должны начинаться с 'T' и быть в формате T<N> или T<N>.<M>, где <N>, <M> - натуральные числа.`);	
+				if (!validationResult) {
+					throw new IncorrectFieldFillingException(`Некорректное заполнение тактики '${attack.Tactic}'. Техники должны начинаться с 'T' и быть в формате T<N> или T<N>.<M>, где <N>, <M> - натуральные числа.`);
 				}
 			}
-			
+
 			metaInfo.setAttacks(attacks);
 		}
 
 		return metaInfo;
 	}
 
-	private filterAndTrimArray(input: any) : string [] {
-		if(!input) {
+	private filterAndTrimArray(input: any): string[] {
+		if (!input) {
 			return [];
 		}
-		return (input as string []).filter(elem => elem && elem != "").map(c => c.trim());
+		return (input as string[]).filter(elem => elem && elem != "").map(c => c.trim());
 	}
 }

--- a/client/templates/MetaInfo.html
+++ b/client/templates/MetaInfo.html
@@ -25,9 +25,9 @@
 	<div id="header">
 		<div id="navigation">
 			<input id="name" type="text" value="{{Name}}" title="{{Name}}" pattern="[A-Z][a-zA-Z0-9_]+">
-			<p>Cоздано: {{Created}} </p>
-			<p>Обновлено: {{Updated}} </p>
-			<p>ID: {{ObjectId}} </p>
+			<p>Cоздано: {{FormattedCreated}}</p>
+			<p>Обновлено: {{FormattedUpdated}}</p>
+			<p>ID: {{ObjectId}}</p>
 		</div>
 
 		<input class="save" name="saveMetainfo" onclick="saveMetaInfo()" type="button" value="Сохранить">
@@ -75,14 +75,6 @@
 					<input id="Updated" readonly type="text" value="{{Updated}}" title="{{Updated}}">
 				</td>
 			</tr>
-
-			<tr class="service">
-				<td class="labels">Origin</td>
-				<td>
-					<input id="Origin" type="text" value="{{Origin}}" title="{{Origin}}">
-				</td>
-			</tr>
-
 			<tr>
 				<td class="labels">Сценарий использования</td>
 				<td>
@@ -147,11 +139,15 @@
 				<td class="labels">Источники данных</td>
 				<td>
 					{{#DataSources}}
-					<div name='dataSource' class="complex">
-						<input name="provider" type="text" value="{{Provider}}" list="providers" required />
-						<input name="eventID" type="text" value="{{EventID}}" title="{{EventID}}" required>
+					<div>
+						{{#EventID}}
+						<div name='dataSource' class="complex">
+							<input name="provider" type="text" value="{{Provider}}" list="providers" required />
+							<input name="eventID" type="text" value="{{.}}" title="{{.}}" required>
 
-						<input class="delete" type="button" value="-" title="-" onclick="deleteValue(this)">
+							<input class="delete" type="button" value="-" title="-" onclick="deleteValue(this)">
+						</div>
+						{{/EventID}}
 					</div>
 					{{/DataSources}}
 					<input class="add_value" type="button" value="+" onclick="addDataSourceComplexValue(this)">
@@ -187,15 +183,6 @@
 					</div>
 					{{/ATTACK}}
 					<input class="add_value" type="button" value="+" onclick="addAttackComplexValue(this)">
-				</td>
-			</tr>
-
-			<tr class="service">
-				<td class="labels">Тег {{tagsIndex}}</td>
-				<td>
-					{{#Tags}}
-					<input name="tag" type="text" value="{{.}}" title="{{.}}">
-					{{/Tags}}
 				</td>
 			</tr>
 		</table>
@@ -256,7 +243,6 @@
 			const newObjectId = document.getElementById("ObjectId")?.value;
 			const newCreated = document.getElementById("Created")?.value;
 			const newUpdated = document.getElementById("Updated")?.value;
-			const newOrigin = document.getElementById("Origin")?.value;
 
 			const usecases = inputsNameToArray("usecase");
 			const knowledgeHolders = inputsNameToArray("knowledgeHolder");
@@ -264,7 +250,6 @@
 			const improvements = inputsNameToArray("improvement");
 
 			const references = inputsNameToArray("reference");
-			const tags = inputsNameToArray("tag");
 
 			// Получаем источники данных
 			const dataSourceElements = Array.from(document.getElementsByName('dataSource'));
@@ -344,14 +329,12 @@
 					'ObjectId': newObjectId,
 					'Created': newCreated,
 					'Updated': newUpdated,
-					'Origin': newOrigin,
 
 					'Usecases': usecases,
 					'KnowledgeHolders': knowledgeHolders,
 					'Falsepositives': falsepositives,
 					'Improvements': improvements,
 					'References': references,
-					'Tags': tags,
 
 					'DataSources': dataSources,
 					'ATTACK': attacks,


### PR DESCRIPTION
Remove deprecated metainfo fields, fix front for datasources, fix date format

Resolves #34 

Dates: (nasty hack)
![pic](https://user-images.githubusercontent.com/17738764/230217489-7221ec4e-8c10-424d-8091-14fd53726e42.png)

EventIDs:
![pic](https://user-images.githubusercontent.com/17738764/230217555-6f6a8137-eb58-4349-b1d6-1835c2659227.png)

Removed `Origin` and `Tags`
