### PR TITLE
Fix metainfo attck parsing

### DIFF
--- a/client/src/models/metaInfo/metaInfo.ts
+++ b/client/src/models/metaInfo/metaInfo.ts
@@ -106,7 +106,15 @@ export class MetaInfo {
 			metaInfo.DataSources = metaDict.DataSources as DataSource[];
 		}
 
-		const attackDict = useExpertContext ? metaInfoAsInFile.ContentRelations.Implements.ATTACK : metaInfoAsInFile.ATTACK;
+		let attackDict = metaInfoAsInFile.ATTACK;
+		if (useExpertContext) {
+			try {
+				attackDict = metaInfoAsInFile.ContentRelations.Implements.ATTACK;
+			}
+			catch (e) {
+				if (!(e instanceof TypeError)) throw e;
+			}
+		}
 		if (attackDict) {
 			metaInfo.ATTACK = Object.keys(attackDict).map(
 				tactic => {


### PR DESCRIPTION
Fixes bug when there was no ATT&CK dict in metainfo file in `ContentRelations.Implements`.