### PR TITLE
Various fixes

### DIFF
--- a/client/src/helpers/yamlHelper.ts
+++ b/client/src/helpers/yamlHelper.ts
@@ -19,7 +19,16 @@ export class YamlHelper {
 		localizationDumpOptions.forceQuotes = true;
 
 		const yamlContent = js_yaml.dump(object, localizationDumpOptions);
-		return yamlContent;
+
+		return prettier.format(
+			yamlContent,
+			{
+				'parser': 'yaml',
+				'tabWidth': this.dumpOptions.indent,
+				'aliasDuplicateObjects': false,
+				'singleQuote': true,
+			}
+		);
 	}
 
 	public static stringify(object: any): string {
@@ -30,6 +39,7 @@ export class YamlHelper {
 			{
 				'parser': 'yaml',
 				'tabWidth': this.dumpOptions.indent,
+				'aliasDuplicateObjects': false,
 				// 'maxLineLength': this.dumpOptions.lineWidth,
 			}
 		);

--- a/client/src/models/metaInfo/metaInfo.ts
+++ b/client/src/models/metaInfo/metaInfo.ts
@@ -334,6 +334,7 @@ export class MetaInfo {
 
 		if (this.Name) {
 			metaInfoObject.ContentAutoName = this.Name;
+			if (metaInfoObject.Name) delete metaInfoObject.Name;
 		}
 
 		if (this.EventDescriptions.length != 0) {


### PR DESCRIPTION
1. Remove `Name` when changing to `ContentAutoName` in `metainfo.yaml`
2. Change yaml formatter for localizations
3. Explicitly disable yaml anchoring feature