### PR TITLE
Фикс вьюшки с модульными тестами и некоторых строк в UI

### DIFF
--- a/client/src/models/tests/correlationUnitTest.ts
+++ b/client/src/models/tests/correlationUnitTest.ts
@@ -17,7 +17,7 @@ export class CorrelationUnitTest extends BaseUnitTest {
 	}
 
 	public getDefaultInputData(): string {
-		return `# Здесь укажи какие нормализованные события ты подаёшь на вход корреляци\n`;
+		return `# Здесь укажи какие нормализованные события (одно или несколько) ты подаёшь на вход правилу корреляции.\n# События отделяются друг от друга символом новой строки. Каждое их них должно быть записано в строку.\n`;
 	}
 
 	public static containsInputData(fileContent) : boolean {

--- a/client/src/models/tests/normalizationUnitTest.ts
+++ b/client/src/models/tests/normalizationUnitTest.ts
@@ -13,7 +13,7 @@ export class NormalizationUnitTest extends BaseUnitTest {
 	}
 
 	public getDefaultInputData(): string {
-		return `# Здесь укажи какие сырые события ты подаёшь на вход нормализации\n`;
+		return `# Здесь укажи какое сырое событие (одно) ты подаёшь на вход правилу нормализации.\n`;
 	}
 
 	public static parseFromRuleDirectory(rule: Normalization) : NormalizationUnitTest [] {

--- a/client/templates/UnitTestEditor.html
+++ b/client/templates/UnitTestEditor.html
@@ -117,9 +117,9 @@ p code {
 		<!-- Common Panel -->
 		<div id="header">
 		{{#UnitTest}}
-			<input id="run_test" class="run {{TestStatus}}" name="run-test" type="button" value="&#9654;   Запустить тест  ">	
+			<input id="run_test" class="run {{TestStatus}}" name="run-test" type="button" value="&#9654;   Запустить  ">	
 		{{/UnitTest}}
-			<input id="save_test" class="save" name="save-test" type="button" value="Сохранить тест">
+			<input id="save_test" class="save" name="save-test" type="button" value="Сохранить">
 	    </div>
 
 		<!-- Tab content -->
@@ -130,7 +130,7 @@ p code {
 			<div class="test_block">			
 				<div class="block_header">
 					<div class="scrolldown" onclick="toggleTextarea(this)">ᐯ</div>
-					<label for="raw-event" class="label">Сырое событие:</label>
+					<label for="raw-event" class="label">Cобытия для модульного теста:</label>
 				</div>
 				
 				<div class="manage_buttons">

--- a/client/templates/js/unittest/code.js
+++ b/client/templates/js/unittest/code.js
@@ -115,26 +115,6 @@ $('textarea').on('focusin', function() {
 });
 
 $(document).ready(function() {
-	// Грязный хак, позволяющий убрать ошибку двойного копирование по сочетаниям Ctrl+C и Ctrl+V.
-	var ctrlDown = false,
-	ctrlKey = 17,
-	cmdKey = 91,
-	vKey = 86,
-	cKey = 67;
-
-	$(document).keydown(function(e) {
-		if (e.keyCode == ctrlKey || e.keyCode == cmdKey) ctrlDown = true;
-	}).keyup(function(e) {
-		if (e.keyCode == ctrlKey || e.keyCode == cmdKey) ctrlDown = false;
-	});
-
-	// Document Ctrl + C/V 
-	$(document).keydown(function(e) {
-		if (ctrlDown && (e.keyCode == vKey)) {
-			e.preventDefault();
-		}
-	});
-
 	raws = $('[name=word-wrap]');
 	for (i = 0; i < raws.length; i++) {
 		wrap(raws[i]);

--- a/package.json
+++ b/package.json
@@ -185,18 +185,18 @@
 		"viewsWelcome": [
 			{
 				"view": "KnowledgebaseTree",
-				"contents": "Привет! Это я - расширение для разработки контента для языка eXtraction and Processing (XP). Чтобы начать работу со мной, открой базу знаний.\n[Открыть базу знаний](command:SiemContentEditor.openKnowledgebaseCommand)\nДа пребудет с тобой сила и достойный контент!"
+				"contents": "Добро пожаловать! Это расширение поможет в разработке правил на языке eXtraction and Processing (XP). Чтобы начать, откройте базу знаний.\n[Открыть базу знаний](command:SiemContentEditor.openKnowledgebaseCommand)\nПриятной работы!"
 			},
 			{
 				"view": "ModularTestsListView",
-				"contents": "Тут будут твои классные юнит-тесты, не забывай про них!"
+				"contents": "Модульные тесты отсутствуют."
 			}
 		],
 		"viewsContainers": {
 			"activitybar": [
 				{
 					"id": "Content",
-					"title": "Редактор контента",
+					"title": "eXtraction and Processing",
 					"icon": "resources/xp.svg"
 				}
 			]
@@ -205,8 +205,8 @@
 			"Content": [
 				{
 					"id": "KnowledgebaseTree",
-					"name": "Дерево контента",
-					"contextualTitle": "Дерево контента"
+					"name": "Дерево объектов",
+					"contextualTitle": "Дерево объектов"
 				},
 				{
 					"id": "ModularTestsListView",
@@ -377,72 +377,72 @@
 			{
 				"command": "xpContentEditor.setContentType",
 				"title": "Выбрать целевой продукт: SIEM или XDR",
-				"category": "Редактор контента"
+				"category": "Редактор XP"
 			},
 			{
 				"command": "SiemContentEditor.openKnowledgebaseCommand",
 				"title": "Открыть базу знаний",
-				"category": "Редактор контента",
+				"category": "Редактор XP",
 				"icon": "$(folder-opened)"
 			},
 			{
 				"command": "SiemContentEditor.refreshKbTree",
-				"title": "Обновить дерево контента",
+				"title": "Обновить дерево объектов",
 				"icon": "$(refresh)"
 			},
 			{
 				"command": "SiemContentEditor.сreatePackageCommand",
-				"title": "Создать пустой пакет",
-				"category": "Редактор контента"
+				"title": "Создать новый пакет",
+				"category": "Редактор XP"
 			},
 			{
 				"command": "KnowledgebaseTree.showCreateCorrelationView",
-				"title": "Создать корреляцию",
-				"category": "Редактор контента",
+				"title": "Создать правило корреляции",
+				"category": "Редактор XP",
 				"icon": "$(file-add)"
 			},
 			{
 				"command": "KnowledgebaseTree.showCreateEnrichmentView",
-				"title": "Создать обогащение",
-				"category": "Редактор контента"
+				"title": "Создать правило обогащения",
+				"category": "Редактор XP"
 			},
 			{
 				"command": "KnowledgebaseTree.showCreateNormalizationView",
-				"title": "Создать нормализацию",
-				"category": "Редактор контента"
+				"title": "Создать правило нормализации",
+				"category": "Редактор XP"
 			},
 			{
 				"command": "TableListsEditorView.showView",
-				"title": "Создать ТС",
-				"shortTitle": "Создать ТС",
-				"category": "Редактор контента"
+				"title": "Создать табличный список",
+				"shortTitle": "Создать табличный список",
+				"category": "Редактор XP"
 			},
 			{
 				"command": "KnowledgebaseTree.runningCorrelationGraph",
 				"title": "Скоррелировать события",
 				"shortTitle": "Скоррелировать события",
-				"category": "Редактор контента",
+				"category": "Редактор XP",
 				"icon": "$(outline-view-icon)"
 			},
 			{
 				"command": "KnowledgebaseTree.buildAll",
-				"title": "Скомпилировать всё (графы, табличные списки, локализации)",
-				"shortTitle": "Скомпилировать всё",
-				"category": "Редактор контента",
+				"title": "Собрать все графы",
+				"shortTitle": "Собрать все графы",
+				"category": "Редактор XP",
 				"icon": "$(debug-start)"
 			},
 			{
 				"command": "KnowledgebaseTree.unpackKbPackage",
-				"title": "Извлечь пакет(ы) из kb-файла",
-				"shortTitle": "Извлечь пакет(ы) из kb-файла",
-				"category": "Редактор контента",
+				"title": "Импортировать пакеты из KB-файла",
+				"shortTitle": "Загрузить пакеты",
+				"category": "Редактор XP",
 				"icon": "$(package)"
 			},
 			{
 				"command": "KnowledgebaseTree.buildKbPackage",
-				"title": "Собрать пакет",
-				"shortTitle": "Собрать пакет в kb-файл",
-				"category": "Редактор контента",
+				"title": "Экспортировать пакет в KB-файл",
+				"shortTitle": "Собрать пакет",
+				"category": "Редактор XP",
 				"icon": "$(debug-start)"
 			},
 			{
@@ -452,74 +452,74 @@
 			},
 			{
 				"command": "SiemContentEditor.createSubFolderCommand",
-				"title": "Создать директорию",
-				"category": "Редактор контента",
+				"title": "Создать папку",
+				"category": "Редактор XP",
 				"icon": "$(new-folder)"
 			},
 			{
 				"command": "SiemContentEditor.renameTreeItemCommand",
 				"title": "Переименовать",
-				"category": "Редактор контента"
+				"category": "Редактор XP"
 			},
 			{
 				"command": "SiemContentEditor.deleteContentItemCommand",
 				"title": "Удалить",
-				"category": "Редактор контента",
+				"category": "Редактор XP",
 				"icon": "$(notebook-delete-cell)"
 			},
 			{
 				"command": "MetaInfoView.showMetaInfoEditor",
-				"title": "Метаданные",
-				"category": "Редактор контента"
+				"title": "Открыть редактор метаданных",
+				"category": "Редактор XP"
 			},
 			{
 				"command": "LocalizationView.showLocalizationEditor",
-				"title": "Правила локализации",
-				"category": "Редактор контента"
+				"title": "Открыть редактор правил локализации",
+				"category": "Редактор XP"
 			},
 			{
 				"command": "ModularTestContentEditorView.showEditor",
 				"title": "Показать модульный тест",
-				"category": "Редактор контента"
+				"category": "Редактор XP"
 			},
 			{
 				"command": "ModularTestsListView.runTests",
-				"title": "Запустить все",
-				"category": "Редактор контента",
+				"title": "Запустить все модульные тесты",
+				"category": "Редактор XP",
 				"icon": "$(run-all)"
 			},
 			{
 				"command": "ModularTestsListView.addTest",
-				"title": "Добавить",
-				"category": "Редактор контента",
+				"title": "Создать модульный тест",
+				"category": "Редактор XP",
 				"icon": "$(add)"
 			},
 			{
 				"command": "ModularTestsListView.reloadAndRefresh",
-				"title": "Обновить",
-				"category": "Редактор контента",
+				"title": "Обновить список модульных тестов",
+				"category": "Редактор XP",
 				"icon": "$(refresh)"
 			},
 			{
 				"command": "ModularTestsListView.removeTest",
-				"title": "Удалить",
-				"category": "Редактор контента",
+				"title": "Удалить модульный тест",
+				"category": "Редактор XP",
 				"icon": "$(refresh)"
 			},
 			{
 				"command": "IntegrationTestEditorView.showEditor",
-				"title": "Тесты",
-				"category": "Редактор контента"
+				"title": "Открыть интеграционные тесты",
+				"category": "Редактор XP"
 			},
 			{
 				"command": "IntegrationTestEditorView.onTestSelectionChange",
 				"title": "Выбран интеграционный тест",
-				"category": "Редактор контента"
+				"category": "Редактор XP"
 			},
 			{
 				"command": "NativeEditorContextMenu.compressTest",
-				"title": "Compress Document",
-				"category": "Редактор контента"
+				"title": "Сжать документ",
+				"category": "Редактор XP"
 			}
 		],
 		"keybindings": [

--- a/package.json
+++ b/package.json
@@ -205,8 +205,8 @@
 			"Content": [
 				{
 					"id": "KnowledgebaseTree",
-					"name": "Дерево объектов",
-					"contextualTitle": "Дерево объектов"
+					"name": "Дерево контента",
+					"contextualTitle": "Дерево контента"
 				},
 				{
 					"id": "ModularTestsListView",
@@ -387,7 +387,7 @@
 			},
 			{
 				"command": "SiemContentEditor.refreshKbTree",
-				"title": "Обновить дерево объектов",
+				"title": "Обновить дерево контента",
 				"icon": "$(refresh)"
 			},
 			{
@@ -426,8 +426,8 @@
 			},
 			{
 				"command": "KnowledgebaseTree.buildAll",
-				"title": "Собрать все графы",
-				"shortTitle": "Собрать все графы",
+				"title": "Собрать всё (графы, табличные списки, локализации)",
+				"shortTitle": "Собрать всё",
 				"category": "Редактор XP",
 				"icon": "$(debug-start)"
 			},
@@ -452,7 +452,7 @@
 			},
 			{
 				"command": "SiemContentEditor.createSubFolderCommand",
-				"title": "Создать папку",
+				"title": "Создать директорию",
 				"category": "Редактор XP",
 				"icon": "$(new-folder)"
 			},
@@ -469,12 +469,12 @@
 			},
 			{
 				"command": "MetaInfoView.showMetaInfoEditor",
-				"title": "Открыть редактор метаданных",
+				"title": "Редактор метаданных",
 				"category": "Редактор XP"
 			},
 			{
 				"command": "LocalizationView.showLocalizationEditor",
-				"title": "Открыть редактор правил локализации",
+				"title": "Редактор правил локализации",
 				"category": "Редактор XP"
 			},
 			{
@@ -508,7 +508,7 @@
 			},
 			{
 				"command": "IntegrationTestEditorView.showEditor",
-				"title": "Открыть интеграционные тесты",
+				"title": "Интеграционные тесты",
 				"category": "Редактор XP"
 			},
 			{


### PR DESCRIPTION
Удалил пропущенный код, который боролся с багом двойной вставки.

Исправил некоторые строки в UI, в частности решены проблемы, указанные в комментариях:
https://github.com/Security-Experts-Community/vscode-xp/issues/99#issue-1737869845
https://github.com/Security-Experts-Community/vscode-xp/issues/99#issuecomment-1573498803
https://github.com/Security-Experts-Community/vscode-xp/issues/99#issuecomment-1573596360