### PR TITLE
Корректное получение сообщения о релизе при публикации в GitHub Actions

### DIFF
--- a/.github/workflows/publish-vsc-marketplace.yml
+++ b/.github/workflows/publish-vsc-marketplace.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Get release version
         id: release_version
         run: |
-          TAGGED_VERSION="${GITHUB_REF/refs\/tags\/v/}"
+          TAGGED_VERSION="${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_ENV
           echo "TAGGED_VERSION=${TAGGED_VERSION}"
           if [[ ! "${TAGGED_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
             echo "Invalid version tag '${TAGGED_VERSION}'"

--- a/.github/workflows/publish-vsc-marketplace.yml
+++ b/.github/workflows/publish-vsc-marketplace.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
 
       - name: Setup Node
         uses: actions/setup-node@v3
@@ -51,8 +53,10 @@ jobs:
 
       - name: Get tag message body
         run: |
-          TAG_BODY="$(git tag -l --format='%(contents:body)' v${TAGGED_VERSION})"
-          echo "${TAG_BODY}" >> $GITHUB_OUTPUT        
+          EOF=${{ github.sha }}
+          echo "msg<<$EOF" >> $GITHUB_OUTPUT
+          echo "$(git tag -l --format='%(contents:body)' ${{ github.ref_name }})" >> $GITHUB_OUTPUT
+          echo "$EOF" >> $GITHUB_OUTPUT      
         id: get_tag_message
 
       - name: Stamp version
@@ -81,7 +85,7 @@ jobs:
           draft: false
           prerelease: ${{env.EXT_ISPREVIEW == 1}}
           body: |
-            ${{join(steps.get_tag_message.outputs.*, '\n')}}
+            ${{ steps.get_tag_message.outputs.msg }}
 
       - name: Upload release asset
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/publish-vsc-marketplace.yml
+++ b/.github/workflows/publish-vsc-marketplace.yml
@@ -6,6 +6,8 @@ on:
       - v*
 jobs:
   release:
+    permissions:
+      contents: write
     name: Create release and publish
     runs-on: ubuntu-latest
     steps:
@@ -72,7 +74,7 @@ jobs:
         id: create_release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.VSCODE_XP_GH_RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
           release_name: v${{ env.EXT_VERSION }}
@@ -84,7 +86,7 @@ jobs:
       - name: Upload release asset
         uses: actions/upload-release-asset@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.VSCODE_XP_GH_RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./vscode-xp-${{ env.EXT_VERSION }}.vsix


### PR DESCRIPTION
В процессе тестирования интеграции [вебхука](https://github.com/leitosama/github-telegram-webhook) я обнаружил, что job'а `get_tag_message` не получает тело сообщения и отдает его пустым в `create_release`:
![image](https://github.com/Security-Experts-Community/vscode-xp/assets/20799025/1a2d68fa-e3a9-4dbb-8839-151cbaeb2f48)

В PR 2 фикса:
- Изменение персонального токена @aw350m33d  `VSCODE_XP_GH_RELEASE_TOKEN` на токен GitHub Actions (см. [пример](https://github.com/actions/create-release/tree/v1/#example-workflow---create-a-release))
- Фикс получения сообщения из тега

Пример работы action'а: https://github.com/leitosama/vscode-xp/actions/runs/5800298877/job/15722105659