### PR TITLE
Добавил поддержку сочетания клавиш CTRL+A в интеграционных тестах

### DIFF
--- a/client/templates/IntegrationTestEditor.html
+++ b/client/templates/IntegrationTestEditor.html
@@ -233,9 +233,9 @@
 						}
 					});
 
-					// Обработка вставки символа.
+					// Обработка вставки символа с поддержкой выделения на Ctrl+A.
 					el.addEventListener('keyup', e => {
-						if (e.keyCode >= 0x30 || e.keyCode == 0x20) {
+						if ((e.keyCode >= 0x30 || e.keyCode == 0x20) && !(e.ctrlKey && e.code == 'KeyA')) {
 							const pos = caret();
 							highlight(el);
 							setCaret(pos);


### PR DESCRIPTION
Проблема с невозможностью выделения на CTRL+A возникала из-за того, что при нажатии на A в сочетании клавиш, хоть и не происходил ввод символа, он всё равно обрабатывался как событие ввода символа и сбрасывал выделение хайлайтом из библиотеки highlight,js.