### PR TITLE
Интеграционные тесты: Ctrl+Z, Ctrl+Y, Tab, хайлайт

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "client",
-    "version": "3.7.4",
+    "version": "3.9.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "client",
-            "version": "3.7.4",
+            "version": "3.9.1",
             "license": "MIT",
             "dependencies": {
                 "guid-typescript": "^1.0.9",

--- a/client/templates/IntegrationTestEditor.html
+++ b/client/templates/IntegrationTestEditor.html
@@ -185,27 +185,8 @@
 					tests: tests
 				});
 			};
-			// Подсветка синтаксиса кода теста.
-			const xpTestCodeHighlighter = el => {
-				const s = el?.innerText;
-				if(!s)  {
-					return;
-				}
-				const highlightNormEvent = hljs.highlight(s, {language: 'xp-test-code'}).value;
-				el.innerHTML = highlightNormEvent;
-			};
-
-			// Подсветка синтаксиса json.
-			const jsonHighlighter = el => {
-				const s = el?.innerText;
-				if(!s)  {
-					return;
-				}
-				const highlightNormEvent = hljs.highlight(s, {language: 'json'}).value;
-				el.innerHTML = highlightNormEvent;
-			};
 			
-			const editor = (el, highlight, tab = '    ') => {
+			const editor = (el, tab = '    ') => {
 					const caret = () => {
 						const range = window.getSelection().getRangeAt(0);
 						const prefix = range.cloneRange();
@@ -238,8 +219,6 @@
 						return pos;
 					};
 
-					highlight(el);
-
 					// Обработка символа табуляции
 					el.addEventListener('keydown', e => {
 						if (e.which === 9) {
@@ -247,7 +226,6 @@
 							const range = window.getSelection().getRangeAt(0);
 							range.deleteContents();
 							range.insertNode(document.createTextNode(tab));
-							highlight(el);
 							setCaret(pos);
 							e.preventDefault();
 						}
@@ -257,7 +235,6 @@
 					el.addEventListener('keyup', e => {
 						if ((e.keyCode >= 0x30 || e.keyCode == 0x20) && !(e.ctrlKey && e.code == 'KeyA')) {
 							const pos = caret();
-							highlight(el);
 							setCaret(pos);
 						}
 					});
@@ -450,12 +427,14 @@
 				// Добавляем автоподстветку для каждого из полей кода тестов.
 				const xpTestElements = document.querySelectorAll(".xp-test_highlight");
 				for(el of xpTestElements) {
-					editor(el, xpTestCodeHighlighter);
+					el.innerHTML = hljs.highlight(el.innerHTML ? el.innerHTML : '', {language: 'xp-test-code'}).value
+					editor(el);
 				}
 
 				const jsonElements = document.querySelectorAll(".json_highlight");
 				for(el of jsonElements) {
-					editor(el, jsonHighlighter);
+					el.innerHTML = hljs.highlight(el.innerHTML ? el.innerHTML : '', {language: 'json'}).value
+					editor(el);
 				}
 			}
 

--- a/client/templates/IntegrationTestEditor.html
+++ b/client/templates/IntegrationTestEditor.html
@@ -225,7 +225,7 @@
 							const pos = caret() + tab.length;
 							const range = window.getSelection().getRangeAt(0);
 							range.deleteContents();
-							range.insertNode(document.createTextNode(tab));
+							document.execCommand("InsertHTML", false, tab);
 							setCaret(pos);
 							e.preventDefault();
 						}
@@ -427,13 +427,13 @@
 				// Добавляем автоподстветку для каждого из полей кода тестов.
 				const xpTestElements = document.querySelectorAll(".xp-test_highlight");
 				for(el of xpTestElements) {
-					el.innerHTML = hljs.highlight(el.innerHTML ? el.innerHTML : '', {language: 'xp-test-code'}).value
+					el.innerHTML = hljs.highlight(el.innerText ? el.innerText : '', {language: 'xp-test-code'}).value
 					editor(el);
 				}
 
 				const jsonElements = document.querySelectorAll(".json_highlight");
 				for(el of jsonElements) {
-					el.innerHTML = hljs.highlight(el.innerHTML ? el.innerHTML : '', {language: 'json'}).value
+					el.innerHTML = hljs.highlight(el.innerText ? el.innerText : '', {language: 'json'}).value
 					editor(el);
 				}
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "xp",
-	"version": "3.7.4",
+	"version": "3.9.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "xp",
-			"version": "3.7.4",
+			"version": "3.9.1",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
 				"@types/fs-extra": "^9.0.12",
 				"@types/mustache": "^4.1.2",
 				"@types/node": "^12.12.0",
-				"@vscode/webview-ui-toolkit": "^1.2.2",
 				"class-transformer": "^0.5.1",
 				"crc-32": "^1.2.2",
 				"diff": "^5.1.0",
@@ -221,42 +220,6 @@
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
-		},
-		"node_modules/@microsoft/fast-element": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@microsoft/fast-element/-/fast-element-1.11.1.tgz",
-			"integrity": "sha512-qBGQ94V4ktMMXmxNdgF78TPNImv2ctXUi3Vzj3j2X71gpUcr+Fkat7mLcTNC3y/Jc4W63fAhK2vP3MkwYRS5kQ=="
-		},
-		"node_modules/@microsoft/fast-foundation": {
-			"version": "2.48.1",
-			"resolved": "https://registry.npmjs.org/@microsoft/fast-foundation/-/fast-foundation-2.48.1.tgz",
-			"integrity": "sha512-gJR/26hhJipsZ4JD5DSOODb3GFYf7vgCnxS2ag4dj+Mi8ytkAwMPglTOv7v0zsJC2CHqOjY8Ixs66dhepgNkeQ==",
-			"dependencies": {
-				"@microsoft/fast-element": "^1.11.1",
-				"@microsoft/fast-web-utilities": "^5.4.1",
-				"tabbable": "^5.2.0",
-				"tslib": "^1.13.0"
-			}
-		},
-		"node_modules/@microsoft/fast-react-wrapper": {
-			"version": "0.1.48",
-			"resolved": "https://registry.npmjs.org/@microsoft/fast-react-wrapper/-/fast-react-wrapper-0.1.48.tgz",
-			"integrity": "sha512-9NvEjru9Kn5ZKjomAMX6v+eF0DR+eDkxKDwDfi+Wb73kTbrNzcnmlwd4diN15ygH97kldgj2+lpvI4CKLQQWLg==",
-			"dependencies": {
-				"@microsoft/fast-element": "^1.9.0",
-				"@microsoft/fast-foundation": "^2.41.1"
-			},
-			"peerDependencies": {
-				"react": ">=16.9.0"
-			}
-		},
-		"node_modules/@microsoft/fast-web-utilities": {
-			"version": "5.4.1",
-			"resolved": "https://registry.npmjs.org/@microsoft/fast-web-utilities/-/fast-web-utilities-5.4.1.tgz",
-			"integrity": "sha512-ReWYncndjV3c8D8iq9tp7NcFNc1vbVHvcBFPME2nNFKNbS1XCesYZGlIlf3ot5EmuOXPlrzUHOWzQ2vFpIkqDg==",
-			"dependencies": {
-				"exenv-es6": "^1.1.1"
-			}
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -531,19 +494,6 @@
 			"resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
 			"integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
 			"dev": true
-		},
-		"node_modules/@vscode/webview-ui-toolkit": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@vscode/webview-ui-toolkit/-/webview-ui-toolkit-1.2.2.tgz",
-			"integrity": "sha512-xIQoF4FC3Xh6d7KNKIoIezSiFWYFuf6gQMdDyKueKBFGeKwaHWEn+dY2g3makvvEsNMEDji/woEwvg9QSbuUsw==",
-			"dependencies": {
-				"@microsoft/fast-element": "^1.6.2",
-				"@microsoft/fast-foundation": "^2.38.0",
-				"@microsoft/fast-react-wrapper": "^0.1.18"
-			},
-			"peerDependencies": {
-				"react": ">=16.9.0"
-			}
 		},
 		"node_modules/acorn": {
 			"version": "7.4.1",
@@ -1207,11 +1157,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/exenv-es6": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/exenv-es6/-/exenv-es6-1.1.1.tgz",
-			"integrity": "sha512-vlVu3N8d6yEMpMsEm+7sUBAI81aqYYuEvfK0jNqmdb/OPXzzH7QWDDnVjMvDSY47JdHEqx/dfC/q8WkfoTmpGQ=="
-		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1759,7 +1704,8 @@
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true
 		},
 		"node_modules/js-yaml": {
 			"version": "4.1.0",
@@ -1854,18 +1800,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/loose-envify": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-			"peer": true,
-			"dependencies": {
-				"js-tokens": "^3.0.0 || ^4.0.0"
-			},
-			"bin": {
-				"loose-envify": "cli.js"
 			}
 		},
 		"node_modules/lru-cache": {
@@ -2254,18 +2188,6 @@
 				"safe-buffer": "^5.1.0"
 			}
 		},
-		"node_modules/react": {
-			"version": "18.2.0",
-			"resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-			"integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-			"peer": true,
-			"dependencies": {
-				"loose-envify": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/readdirp": {
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -2519,11 +2441,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/tabbable": {
-			"version": "5.3.3",
-			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
-			"integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA=="
-		},
 		"node_modules/table": {
 			"version": "6.8.1",
 			"resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
@@ -2583,7 +2500,8 @@
 		"node_modules/tslib": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"dev": true
 		},
 		"node_modules/tsutils": {
 			"version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -594,7 +594,6 @@
 		"@types/fs-extra": "^9.0.12",
 		"@types/mustache": "^4.1.2",
 		"@types/node": "^12.12.0",
-		"@vscode/webview-ui-toolkit": "^1.2.2",
 		"class-transformer": "^0.5.1",
 		"crc-32": "^1.2.2",
 		"diff": "^5.1.0",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "server",
-    "version": "3.7.4",
+    "version": "3.9.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "server",
-            "version": "3.7.4",
+            "version": "3.9.1",
             "license": "MIT",
             "dependencies": {
                 "@types/vscode": "^1.52.0",


### PR DESCRIPTION
1. Добавил поддержку Ctrl+Z и Ctrl+Y в интеграционных тестах.
2. Уменьшил количество вызовов функции хайлайта символов
3. Исправил ошибку форматирования при нормализации и обогащении сырых событий для интеграционных тестов (&lt = <; &gt; = > и т.д.)
4. Переделал программную мутацию DOM для вставки четырёх пробелов через tab так, чтобы это действие попадало в стек отмены и могло быть отменено/возвращено через Ctrl+Z и Ctrl+Y
