### PR TITLE
Fixed unit test editor issues

### DIFF
--- a/client/src/models/tests/correlationUnitTest.ts
+++ b/client/src/models/tests/correlationUnitTest.ts
@@ -13,7 +13,18 @@ import { StringHelper } from '../../helpers/stringHelper';
 
 export class CorrelationUnitTest extends BaseUnitTest {
   public getDefaultExpectation(): string {
-    return `# Тут будет твой тест. В секции expect укажи сколько и каких корреляционных событий ты ожидаешь\nexpect 1 {"correlation_name":"${this._rule.getName()}"}\n`;
+    return `# Тут будет твой модульный тест.
+# Пример:
+## создать для теста временную БД с табличными списками
+# table_list default
+## ожидаемое заполнение табличных списков
+# table_list {"AD_Domain_Controllers":[{"ip":"8.8.8.8","hostname":"dc.contoso.com"}]}
+## ожидаеммые события
+# expect <число>|not|any {<через запятую пары "поле":"значение">}
+    
+table_list default
+table_list {}
+expect 1 {"correlation_name":"${this._rule.getName()}"}\n`;
   }
 
   public getDefaultInputData(): string {
@@ -52,15 +63,15 @@ export class CorrelationUnitTest extends BaseUnitTest {
 
     const inputDataStrings: string[] = [];
 
-    const table_list_default = /(?:^#.*$|\r?\n)*^table_list\s+default$/m.exec(testFileContent);
-    if (table_list_default && table_list_default.length === 1) {
-      inputDataStrings.push(table_list_default[0].trim());
-    }
+    // const table_list_default = /(?:^#.*$|\r?\n)*^table_list\s+default$/m.exec(testFileContent);
+    // if (table_list_default && table_list_default.length === 1) {
+    //   inputDataStrings.push(table_list_default[0].trim());
+    // }
 
-    const table_list = /(?:^#.*$|\r?\n)*^table_list\s+\{.*?\}$/m.exec(testFileContent);
-    if (table_list && table_list.length === 1) {
-      inputDataStrings.push(table_list[0].trim());
-    }
+    // const table_list = /(?:^#.*$|\r?\n)*^table_list\s+\{.*?\}$/m.exec(testFileContent);
+    // if (table_list && table_list.length === 1) {
+    //   inputDataStrings.push(table_list[0].trim());
+    // }
 
     let m: RegExpExecArray;
     const event_pattern = /(?:^#.*?$|\s)*(?:^\{.*?\}$)/gm;

--- a/client/src/views/integrationTests/command/saveAllCommand.ts
+++ b/client/src/views/integrationTests/command/saveAllCommand.ts
@@ -89,7 +89,7 @@ export class SaveAllCommand extends Command {
 
       // Проверяем наличие проверки ожидаемых событий
       if (
-        !/(\bexpect\b\s+(\d+|not))|(\bexpect\b\s+\btable_list\b)\s+{[\s\S]*?}$/gm.test(testCode)
+        !/(\bexpect\b\s+(\d+|not|any))|(\bexpect\b\s+\btable_list\b)\s+{[\s\S]*?}$/gm.test(testCode)
       ) {
         throw new XpException(
           this.params.config.getMessage('View.IntegrationTests.Message.InvalidTestCode', number)

--- a/client/src/views/unitTestEditor/unitTestEditorViewProvider.ts
+++ b/client/src/views/unitTestEditor/unitTestEditorViewProvider.ts
@@ -113,7 +113,7 @@ export class UnitTestContentEditorViewProvider extends WebViewProviderBase {
         WordWrap: getTranslation('View.UnitTests.WordWrap'),
         ActualResult: getTranslation('View.UnitTests.ActualResult'),
         ConditionForPassingTheTest: getTranslation('View.UnitTests.ConditionForPassingTheTest'),
-        CorrelationRawEvents: getTranslation('View.UnitTests.CorrelationRawEvents'),
+        CorrelationNormalizedEvents: getTranslation('View.UnitTests.CorrelationNormalizedEvents'),
         NormalizationRawEvents: getTranslation('View.UnitTests.NormalizationRawEvents'),
         ReplaceExpectedEventWithActual: getTranslation(
           'View.UnitTests.ReplaceExpectedEventWithActual'

--- a/client/templates/IntegrationTestEditor.html
+++ b/client/templates/IntegrationTestEditor.html
@@ -723,7 +723,7 @@
 				// TODO: Перенести выше.
 				// Добавляем наши ключевые слова в json.
 				const xpTestCode = hljs.getLanguage('json');
-				xpTestCode.keywords.literal.push('not', 'expect', 'table_list', 'default');
+				xpTestCode.keywords.literal.push('any', 'not', 'expect', 'table_list', 'default');
 				xpTestCode.contains.push({begin:"#", end: "$", scope: "comment"});
 				hljs.registerLanguage(
 					'xp-test-code', 

--- a/client/webview/src/pages/unit-test-editor/components/input-editor/input-editor.tsx
+++ b/client/webview/src/pages/unit-test-editor/components/input-editor/input-editor.tsx
@@ -11,7 +11,7 @@ function InputEditor() {
     <CodeSection
       title={
         ruleType == 'correlation'
-          ? translations.CorrelationRawEvents
+          ? translations.CorrelationNormalizedEvents
           : translations.NormalizationRawEvents
       }
       language="json-lines"

--- a/client/webview/src/ui/code-editor/monaco.ts
+++ b/client/webview/src/ui/code-editor/monaco.ts
@@ -10,6 +10,25 @@ export const initMonaco = (monaco: Monaco) => {
   // Add XP test files highlighting
   const XPTestCodeLanguage = 'xp-test-code';
   monaco.languages.register({ id: XPTestCodeLanguage });
+  monaco.languages.setLanguageConfiguration(XPTestCodeLanguage, {
+    comments: {
+      lineComment: '#'
+    },
+    brackets: [
+      ['{', '}'],
+      ['[', ']']
+    ],
+    autoClosingPairs: [
+      { open: '{', close: '}', notIn: ['string', 'comment'] },
+      { open: '[', close: ']', notIn: ['string', 'comment'] },
+      { open: '"', close: '"', notIn: ['string', 'comment'] }
+    ],
+    surroundingPairs: [
+      { open: '{', close: '}' },
+      { open: '[', close: ']' },
+      { open: '"', close: '"' }
+    ]
+  });
   monaco.languages.setMonarchTokensProvider(XPTestCodeLanguage, {
     tokenizer: {
       root: [
@@ -17,7 +36,7 @@ export const initMonaco = (monaco: Monaco) => {
         [/-?\d+(\.\d+)?/, 'number'],
         [/".*?"/, 'string'],
         [/\b(true|false|null)\b/, 'constant'],
-        [/\b(not|expect|table_list|default)\b/, 'keyword']
+        [/\b(not|any|expect|table_list|default)\b/, 'keyword']
       ]
     }
   });

--- a/l10n/xp.nls.en.json
+++ b/l10n/xp.nls.en.json
@@ -266,7 +266,7 @@
     "View.UnitTests.WordWrap": "Word wrap",
     "View.UnitTests.ActualResult": "Actual result",
     "View.UnitTests.ConditionForPassingTheTest": "Test code",
-    "View.UnitTests.CorrelationRawEvents": "Raw events in envelope (JSON Lines)",
+    "View.UnitTests.CorrelationNormalizedEvents": "Normalized events (JSON Lines)",
     "View.UnitTests.NormalizationRawEvents": "Raw events",
     "View.UnitTests.CouldNotOpenTheTest" : "Couldn't open the modular test",
     "View.UnitTests.NoActualEvent": "The actual event hasn't been received. Run the test to receive the actual event, and then you can replace the expected event with the actual one",

--- a/l10n/xp.nls.ru.json
+++ b/l10n/xp.nls.ru.json
@@ -267,7 +267,7 @@
     "View.UnitTests.ActualResult" : "Фактический результат",
     "View.UnitTests.ConditionForPassingTheTest" : "Код теста",
     "View.UnitTests.NormalizationRawEvents" : "Необработанные события",
-    "View.UnitTests.CorrelationRawEvents" : "Необработанные события в конверте (JSON Lines)",
+    "View.UnitTests.CorrelationNormalizedEvents" : "Нормализованные события (JSON Lines)",
     "View.UnitTests.CouldNotOpenTheTest" : "Не удалось открыть модульный тест",
     "View.UnitTests.NoActualEvent": "Фактическое событие не получено. Запустите тест для получения фактического события, после чего можно заменить ожидаемое событие фактическим",
     "View.UnitTests.ReplaceExpectedEventWithActual" : "Заменить ожидаемое событие фактическим в тесте",

--- a/package.json
+++ b/package.json
@@ -298,7 +298,7 @@
         },
         {
           "command": "ModularTestEditorView.showEditor",
-          "when": "view == KnowledgebaseTree && (viewItem == Normalization || viewItem == Correlation || viewItem == Enrichment)",
+          "when": "view == KnowledgebaseTree && viewItem == Correlation",
           "group": "Correlation@2"
         },
         {
@@ -322,6 +322,11 @@
           "group": "Aggregation@3"
         },
         {
+          "command": "ModularTestEditorView.showEditor",
+          "when": "view == KnowledgebaseTree && viewItem == Normalization",
+          "group": "Normalization@1"
+        },
+        {
           "command": "LocalizationView.showLocalizationEditor",
           "when": "view == KnowledgebaseTree && viewItem == Normalization",
           "group": "Normalization@2"
@@ -332,9 +337,19 @@
           "group": "Enrichment@1"
         },
         {
-          "command": "LocalizationView.showLocalizationEditor",
+          "command": "ModularTestEditorView.showEditor",
+          "when": "view == KnowledgebaseTree && viewItem == Enrichment",
+          "group": "Enrichment@2"
+        },
+        {
+          "command": "MetaInfoView.showMetaInfoEditor",
           "when": "view == KnowledgebaseTree && viewItem == Enrichment",
           "group": "Enrichment@3"
+        },
+        {
+          "command": "LocalizationView.showLocalizationEditor",
+          "when": "view == KnowledgebaseTree && viewItem == Enrichment",
+          "group": "Enrichment@4"
         },
         {
           "command": "LocalizationView.showLocalizationEditor",

--- a/syntaxes/test.tmLanguage.json
+++ b/syntaxes/test.tmLanguage.json
@@ -12,7 +12,7 @@
         },
         {
             "name": "keyword.control.xp",
-            "match": "\\b(not|table_list|default|expect)\\b"
+            "match": "\\b(any|not|table_list|default|expect)\\b"
         },
 		{
 			"comment": "Ключ в json-е выделяем отдельно, дабы не сливался со значением",


### PR DESCRIPTION
1. Исправлена проблема парсинга теста из issue #219
2. Исправлена надпись в редакторе модульных тестов
3. Добавлена поддержка ключевого слова any в тестах
4. В редакторе модульных тестов: восстановлен функционал по комментированию строк по Ctrl+/, добавлены автозакрывающиеся пары символов и их подсветка
5. Контекстные меню для корреляций и обогащений приведены к единому виду

fixes: #219