### PR TITLE
Доработки выбора KBT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ contract
 *.tsbuildinfo
 
 mitre_attack/data/parsed/attack.json
+*.vsix

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -248,7 +248,7 @@ async function configureLSPClient(
         }
       };
 
-      client = new LanguageClient(command, serverOptions, clientOptions);
+      client = new LanguageClient(command, 'XP Language Server', serverOptions, clientOptions);
 
       return client
         .start()

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -71,6 +71,23 @@ export async function activate(context: ExtensionContext): Promise<void> {
     await UserSettingsManager.init(config);
     // await ToolsManager.init(config);
 
+    // Ensure automatic KBT selection happens early
+    try {
+      // This will trigger auto-selection if needed
+      const kbtBaseDirectory = config.getKbtBaseDirectoryOld();
+    } catch (error) {
+      Log.warn(`Error during KBT auto-selection: ${error.message}`);
+    }
+
+    // Automatically set configuration options if not already set
+    try {
+      config.autoSetKbtVersionsDirectory();
+      config.autoSetKbtBaseDirectory();
+      config.autoSetLspServerExecutablePath();
+    } catch (error) {
+      Log.warn(`Error during automatic configuration setting: ${error.message}`);
+    }
+
     try {
       await config.checkUserSetting();
     } catch (error) {

--- a/client/src/models/configuration.ts
+++ b/client/src/models/configuration.ts
@@ -275,7 +275,15 @@ export class Configuration {
 
   public getKbtVersionsDirectory(): string {
     const configuration = this.getWorkspaceConfiguration();
-    return configuration.get<string>('kbtVersionsDirectory');
+    const kbtVersionsDirectory = configuration.get<string>('kbtVersionsDirectory');
+    
+    // If no explicit kbtVersionsDirectory is set, use global storage as default
+    if (!kbtVersionsDirectory) {
+      const globalStorageUri = this.context.globalStorageUri;
+      return vscode.Uri.joinPath(globalStorageUri, 'kbt').fsPath;
+    }
+    
+    return kbtVersionsDirectory;
   }
 
   /**

--- a/client/src/models/configuration.ts
+++ b/client/src/models/configuration.ts
@@ -21,6 +21,7 @@ import { Log } from '../extension';
 export type EncodingType = 'windows-1251' | 'utf-8' | 'utf-16';
 
 export class Configuration {
+  private static autoSelectKBTExecuted = false;
   private constructor(context: vscode.ExtensionContext) {
     this.context = context;
 
@@ -268,9 +269,102 @@ export class Configuration {
   public getKbtBaseDirectoryOld(): string {
     const configuration = this.getWorkspaceConfiguration();
     const basePath = configuration.get<string>('kbtBaseDirectory');
+    
+    // If kbtBaseDirectory is not set, try to auto-select first available KBT
+    if (!basePath) {
+      this.autoSelectKBT();
+      // Get the base path after auto-selection without recursive call
+      const newBasePath = configuration.get<string>('kbtBaseDirectory');
+      if (newBasePath) {
+        return newBasePath;
+      }
+      // Fallback if auto-selection didn't work
+      throw new XpException(this.getMessage('Error.KbtDirectoryPathIsNotSet'));
+    }
+    
     this.checkKbtSetting(configuration);
 
     return basePath;
+  }
+
+  /**
+   * Helper method to select the first available KBT version and set the kbtBaseDirectory
+   * if it hasn't been set previously
+   */
+  private selectAndSetKBT(): boolean {
+    try {
+      const kbtVersionsDirectory = this.getKbtVersionsDirectory();
+      
+      // Check if kbtVersionsDirectory exists
+      if (!kbtVersionsDirectory || !fs.existsSync(kbtVersionsDirectory)) {
+        Log.warn('KBT versions directory not found');
+        return false;
+      }
+      
+      // Read the directory contents to find available KBT versions
+      const kbtVersions = fs.readdirSync(kbtVersionsDirectory);
+      
+      // Filter for valid KBT version folders (matching the pattern kbt.x.x)
+      const kbtVersionFolders = kbtVersions.filter((folder) => folder.match(/^kbt(\.\d+)+$/));
+      
+      if (kbtVersionFolders.length === 0) {
+        Log.warn('No KBT version folders found in the KBT versions directory');
+        return false;
+      }
+      
+      // Sort versions to ensure consistent selection (optional)
+      kbtVersionFolders.sort();
+      
+      // Select the first available version
+      const firstKBTVersion = kbtVersionFolders[0];
+      
+      // Set the KBT version in workspace state
+      this.setKBTVersion(firstKBTVersion);
+      
+      // Set the kbtBaseDirectory configuration if not already set
+      const configuration = this.getWorkspaceConfiguration();
+      const kbtBaseDirectory = configuration.get<string>('kbtBaseDirectory');
+      
+      if (!kbtBaseDirectory) {
+        const kbtBasePath = path.join(kbtVersionsDirectory, firstKBTVersion);
+        // Validate that the path actually exists before setting it
+        if (fs.existsSync(kbtBasePath)) {
+          configuration.update('kbtBaseDirectory', kbtBasePath, true, false);
+          Log.info(`Automatically set KBT base directory to: ${kbtBasePath}`);
+          return true;
+        } else {
+          Log.warn(`KBT base path does not exist: ${kbtBasePath}`);
+          return false;
+        }
+      }
+      
+      Log.info(`Automatically selected KBT version: ${firstKBTVersion}`);
+      return true;
+    } catch (error) {
+      Log.warn(`Failed to auto-select KBT: ${error.message}`);
+      return false;
+    }
+  }
+
+  /**
+   * Automatically selects the first available KBT version and sets the kbtBaseDirectory
+   * if it hasn't been set previously
+   */
+  private autoSelectKBT(): void {
+    try {
+      // Prevent multiple executions
+      if (Configuration.autoSelectKBTExecuted) {
+        return;
+      }
+      
+      const success = this.selectAndSetKBT();
+      if (success) {
+        Configuration.autoSelectKBTExecuted = true;
+      }
+    } catch (error) {
+      Log.warn(`Failed to auto-select KBT: ${error.message}`);
+      Configuration.autoSelectKBTExecuted = true;
+    }
   }
 
   public getKbtVersionsDirectory(): string {
@@ -597,22 +691,9 @@ export class Configuration {
     let fullPath = path.join(this.getSiemSdkDirectoryPath(), 'cli', appName);
     if (!fs.existsSync(fullPath)) {
       Log.warn(
-        `Can't find LSP server executable in KBT directory: '${fullPath}'. Trying to find direct LSP server path in settings`
+        `Can't find LSP server executable in KBT directory: '${fullPath}'.`
       );
-
-      // Try to find direct LSP path setting
-      const directLSPPath = this.getDirectLSPServerExecutablePath();
-      if (!directLSPPath) {
-        Log.warn("Can't find LSP server path direct settings");
-        throw new XpException(this.getMessage('Error.UtilityPathIsIncorrect', fullPath));
-      }
-
-      // Found setting, check if executable presents
-      if (!fs.existsSync(directLSPPath)) {
-        Log.warn(`Can't find LSP server executable by direct setting: '${directLSPPath}'`);
-        throw new XpException(this.getMessage('Error.UtilityPathIsIncorrect', fullPath));
-      }
-      fullPath = directLSPPath;
+      return null;
     }
 
     return fullPath;
@@ -939,6 +1020,68 @@ export class Configuration {
     return lspServerExecutablePath;
   }
 
+  /**
+   * Automatically sets kbtVersionsDirectory if not already set
+   */
+  public autoSetKbtVersionsDirectory(): void {
+    const configuration = this.getWorkspaceConfiguration();
+    const kbtVersionsDirectory = configuration.get<string>('kbtVersionsDirectory');
+    
+    if (!kbtVersionsDirectory) {
+      // Use global storage as default if not explicitly set
+      const globalStorageUri = this.context.globalStorageUri;
+      const defaultKbtVersionsDirectory = vscode.Uri.joinPath(globalStorageUri, 'kbt').fsPath;
+      
+      try {
+        configuration.update('kbtVersionsDirectory', defaultKbtVersionsDirectory, true, false);
+        Log.info(`Automatically set kbtVersionsDirectory to: ${defaultKbtVersionsDirectory}`);
+      } catch (error) {
+        Log.warn(`Failed to automatically set kbtVersionsDirectory: ${error.message}`);
+      }
+    }
+  }
+
+  /**
+   * Automatically sets kbtBaseDirectory if not already set
+   */
+  public autoSetKbtBaseDirectory(): void {
+    const configuration = this.getWorkspaceConfiguration();
+    const kbtBaseDirectory = configuration.get<string>('kbtBaseDirectory');
+    
+    if (!kbtBaseDirectory) {
+      // Try to auto-select KBT if we can find it
+      try {
+        this.selectAndSetKBT();
+      } catch (error) {
+        Log.warn(`Failed to auto-select KBT for kbtBaseDirectory: ${error.message}`);
+      }
+    }
+  }
+
+  /**
+   * Automatically sets lspServerExecutablePath if not already set
+   */
+  public autoSetLspServerExecutablePath(): void {
+    const configuration = this.getWorkspaceConfiguration();
+    const lspServerExecutablePath = configuration.get<string>('lspServerExecutablePath');
+    
+    if (!lspServerExecutablePath) {
+      try {
+        // Try to find the LSP server executable in the KBT directory
+        const fullPath = this.getKBTLSPFullPath();
+        
+        if (fullPath) {
+          configuration.update('lspServerExecutablePath', fullPath, true, false);
+          Log.info(`Automatically set lspServerExecutablePath to: ${fullPath}`);
+        } else {
+          Log.warn('LSP server executable not found');
+        }
+      } catch (error) {
+        Log.warn(`Failed to automatically set lspServerExecutablePath: ${error.message}`);
+      }
+    }
+  }
+
   public getLogLevel(): LogLevel {
     const configuration = this.getWorkspaceConfiguration();
     const logLevel = configuration.get<string>('logLevel');
@@ -1014,7 +1157,6 @@ export class Configuration {
 
     // Порядок обратный по приоритету, так как вторая ошибка появится выше чем первая.
     await this.checkAndCreateOutputDirectory(extensionConfig);
-    this.checkKbtSetting(extensionConfig);
   }
 
   private checkKbtSetting(extensionConfig: vscode.WorkspaceConfiguration) {

--- a/client/src/models/configuration.ts
+++ b/client/src/models/configuration.ts
@@ -85,7 +85,7 @@ export class Configuration {
   public craftLSPi18nTaxonomyPath(): string {
     return path.join(
       this.getKbtBaseDirectory(),
-      'knowledgebase/contracts/taxonomy/i18n/i18n_ru.yaml'
+      'knowledgebase/contracts/taxonomy/i18n/'
     );
   }
 

--- a/client/src/models/siemj/setKBTVersionCommand.ts
+++ b/client/src/models/siemj/setKBTVersionCommand.ts
@@ -67,8 +67,46 @@ export class SetKBTVersionCommand {
       }
     }
 
+    // Store the old version for comparison
+    const oldKbtVersion = config.getKbtVersion();
+    
     config.setKBTVersion(kbtVersion);
     Log.info(`Current KBT version: ${kbtVersion}`);
+
+    // Update kbtBaseDirectory to point to the new version
+    const kbtVersionsDirectory = config.getKbtVersionsDirectory();
+    if (kbtVersionsDirectory) {
+      const newKbtBaseDirectory = join(kbtVersionsDirectory, kbtVersion);
+      try {
+        // Only update if the directory exists
+        if (fs.existsSync(newKbtBaseDirectory)) {
+          const configuration = config.getWorkspaceConfiguration();
+          configuration.update('kbtBaseDirectory', newKbtBaseDirectory, true, false);
+          Log.info(`Updated kbtBaseDirectory to: ${newKbtBaseDirectory}`);
+        }
+      } catch (error) {
+        Log.warn(`Failed to update kbtBaseDirectory: ${error.message}`);
+      }
+    }
+
+    // Update lspServerExecutablePath to point to the new version
+    try {
+      // Use the existing getKBTLSPFullPath method to determine the LSP server path
+      // This ensures consistency with the rest of the codebase
+      const lspServerPath = config.getKBTLSPFullPath();
+      
+      // Check if the path is valid and update the configuration
+      const configuration = config.getWorkspaceConfiguration();
+      if (lspServerPath && fs.existsSync(lspServerPath)) {
+        configuration.update('lspServerExecutablePath', lspServerPath, true, false);
+        Log.info(`Updated lspServerExecutablePath to: ${lspServerPath}`);
+      } else {
+        configuration.update('lspServerExecutablePath', '', true, false);
+        Log.warn(`LSP server not found`);
+      }
+    } catch (error) {
+      Log.warn(`Failed to update lspServerExecutablePath: ${error.message}`);
+    }
 
     Log.debug('-= Updating LSP configuration =-');
 

--- a/client/src/models/siemj/setKBTVersionCommand.ts
+++ b/client/src/models/siemj/setKBTVersionCommand.ts
@@ -110,19 +110,11 @@ export class SetKBTVersionCommand {
 
     Log.debug('-= Updating LSP configuration =-');
 
-    const currentLSPTaxonomyPath = config.getLSPTaxonomyPath();
-    Log.debug(`Current LSP taxonomy path: ${currentLSPTaxonomyPath}`);
-    if (config.craftLSPTaxonomyPath() === currentLSPTaxonomyPath) {
-      await config.updateLSPTaxonomyPath();
-      Log.debug(`New LSP taxonomy path: ${config.getLSPTaxonomyPath()}`);
-    }
+    await config.updateLSPTaxonomyPath();
+    Log.debug(`New LSP taxonomy path: ${config.getLSPTaxonomyPath()}`);
 
-    const currentLSPi18nTaxonomyPath = config.getLSPi18nTaxonomyPath();
-    Log.debug(`Current LSP i18n taxonomy path: ${currentLSPi18nTaxonomyPath}`);
-    if (config.craftLSPi18nTaxonomyPath() === currentLSPi18nTaxonomyPath) {
-      await config.updateLSPi18nTaxonomyPath();
-      Log.debug(`New LSP i18n taxonomy path: ${config.getLSPi18nTaxonomyPath()}`);
-    }
+    await config.updateLSPi18nTaxonomyPath();
+    Log.debug(`New LSP i18n taxonomy path: ${config.getLSPi18nTaxonomyPath()}`);
 
     const propertiesFile = join(config.getKbtBaseDirectory(), 'properties');
 


### PR DESCRIPTION
1. Автоматический выбор пути `{globalStorageUri}/kbt` в качестве `kbtVersionsDirectory`
2. Автоматический выбор первого KBT из `kbtVersionsDirectory` (нужно для возможности собрать удобный portable bundle)
3. При выборе KBT автоматически заполняются `lspServerExecutablePath`, `taxonomy_path`, `taxonomy_i18n_path`