### PR TITLE
Добавлен новый include для конфига интеграционных тестов

### DIFF
--- a/client/src/models/siemj/siemjConfigBuilder.ts
+++ b/client/src/models/siemj/siemjConfigBuilder.ts
@@ -611,7 +611,8 @@ out=${output}
       "body"
     ],
     "include": [
-      "_dropped"
+      "_dropped",
+      "_applied_enrichment_rules"
     ],
     "filter-expect-events": [
       "correlation_name",


### PR DESCRIPTION
Поле _applied_enrichment_rules хранит список примененных правил обогащения (доступно не во всех релизах kbt)